### PR TITLE
Use GitHub App client ID for project sync token

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -8,7 +8,7 @@ name: add-to-project
 # a repo secret.
 #
 # Required configuration (already set on all 6 feeder repos):
-#   vars.PROJECT_APP_ID           = 3422407
+#   vars.PROJECT_APP_CLIENT_ID      = Iv23liL4dLxjYFwTNWKt
 #   vars.PROJECT_OWNER            = FastLED
 #   vars.PROJECT_NUMBER           = 1
 #   secrets.PROJECT_APP_PRIVATE_KEY = <PEM contents>
@@ -30,13 +30,13 @@ permissions:
 jobs:
   add:
     runs-on: ubuntu-latest
-    if: ${{ vars.PROJECT_APP_ID != '' && vars.PROJECT_OWNER != '' }}
+    if: ${{ vars.PROJECT_APP_CLIENT_ID != '' && vars.PROJECT_OWNER != '' }}
     steps:
       - name: Generate App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.PROJECT_APP_ID }}
+          client-id: ${{ vars.PROJECT_APP_CLIENT_ID }}
           private-key: ${{ secrets.PROJECT_APP_PRIVATE_KEY }}
           owner: ${{ vars.PROJECT_OWNER }}
 


### PR DESCRIPTION
## Summary
- update add-to-project workflow to use actions/create-github-app-token@v3
- switch token generation from legacy PROJECT_APP_ID to PROJECT_APP_CLIENT_ID
- add the matching PROJECT_APP_CLIENT_ID repo Actions variable

## Notes
This does not install the GitHub App. The FastLED-owned app with client ID Iv23liL4dLxjYFwTNWKt still needs to be installed on the FastLED org for token generation to succeed.

Related: FastLED/FastLED#2383