### PR TITLE
Add ESP32 PARLIO-capable boards (C5/C6/H2/P4) with required ISR-IRAM flags

### DIFF
--- a/platforms/platformio.esp32c6.ini
+++ b/platforms/platformio.esp32c6.ini
@@ -10,13 +10,10 @@
 
 
 [env:esp32c6] ; the esp32c6 part can be renamed to anything you want.
-; Note that this special platform override is used to bring in the
-; idf5.1 toolchain that is now included in Arduino 2.3.1+, and may
-; not be necessary in the near future.
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/51.03.04/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.35/platform-espressif32.zip
 framework = arduino
-; This is a popular ESP32-S3 board.
 board = esp32-c6-devkitc-1
+board_build.partitions = huge_app.csv
 
 upload_protocol = esptool
 monitor_speed = 115200
@@ -29,8 +26,14 @@ monitor_filters =
 	default
 	esp32_exception_decoder
 
-; ---- CRITICAL: enable USB CDC serial ----
+; PARLIO ISR flags: only set on chips with the PARLIO peripheral (C5/C6/H2/P4).
+; Without these the FastLED PARLIO TX ISR sits in flash and takes cache-miss
+; stalls during execution, silently corrupting LED protocol timing.
+; See FastLED src/platforms/esp/32/drivers/parlio/ for the canonical chipset list.
 build_flags =
+    -DCONFIG_PARLIO_TX_ISR_HANDLER_IN_IRAM=1
+    -DCONFIG_PARLIO_TX_ISR_CACHE_SAFE=1
+    ; ---- CRITICAL: enable USB CDC serial ----
     -D ARDUINO_USB_CDC_ON_BOOT=1
     -D ARDUINO_USB_MODE=1
 

--- a/platforms/platformio.esp32h2.ini
+++ b/platforms/platformio.esp32h2.ini
@@ -9,9 +9,17 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:esp32h2]
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/53.03.10/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.35/platform-espressif32.zip
 board = esp32-h2-devkitm-1
 framework = arduino
+
+; PARLIO ISR flags: only set on chips with the PARLIO peripheral (C5/C6/H2/P4).
+; Without these the FastLED PARLIO TX ISR sits in flash and takes cache-miss
+; stalls during execution, silently corrupting LED protocol timing.
+; See FastLED src/platforms/esp/32/drivers/parlio/ for the canonical chipset list.
+build_flags =
+  -DCONFIG_PARLIO_TX_ISR_HANDLER_IN_IRAM=1
+  -DCONFIG_PARLIO_TX_ISR_CACHE_SAFE=1
 
 lib_deps =
   FastLED

--- a/platforms/platformio.esp32p4.ini
+++ b/platforms/platformio.esp32p4.ini
@@ -8,10 +8,11 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-[env:esp32c5]
+[env:esp32p4]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.35/platform-espressif32.zip
-board = esp32-c5-devkitc-1
+board = esp32-p4-evboard
 framework = arduino
+board_build.partitions = huge_app.csv
 
 ; PARLIO ISR flags: only set on chips with the PARLIO peripheral (C5/C6/H2/P4).
 ; Without these the FastLED PARLIO TX ISR sits in flash and takes cache-miss
@@ -20,6 +21,7 @@ framework = arduino
 build_flags =
   -DCONFIG_PARLIO_TX_ISR_HANDLER_IN_IRAM=1
   -DCONFIG_PARLIO_TX_ISR_CACHE_SAFE=1
+  -DARDUINO_USB_MODE=1
 
 lib_deps =
   FastLED


### PR DESCRIPTION
## Summary

- Add the two required PARLIO TX ISR build flags (`CONFIG_PARLIO_TX_ISR_HANDLER_IN_IRAM=1` and `CONFIG_PARLIO_TX_ISR_CACHE_SAFE=1`) to every ESP32 chip whose SoC capabilities expose PARLIO: C5, C6, H2, P4.
- Add a new `platforms/platformio.esp32p4.ini` env (the P4 was completely missing).
- Bump the pioarduino platform-package on the C5/C6/H2 envs to `55.03.35` for consistency with the newly added P4 env.
- Add a comment block next to the flags pointing future maintainers at FastLED `src/platforms/esp/32/drivers/parlio/` as the canonical PARLIO-capable chipset list.

## Why

Without these flags the FastLED PARLIO driver's TX ISR sits in flash and takes cache-miss stalls during execution, silently corrupting LED protocol timing. The FastLED driver only signals their absence with a compile-time `#warning`, which is easy to miss.

## Boards explicitly NOT modified

S3 / C3 / C2 / S2 / original-ESP32 envs are intentionally left without the PARLIO flags — those chips don't have the PARLIO peripheral (`SOC_PARLIO_SUPPORTED=0`) and adding the flags would falsely imply they do.

## Test plan

- [ ] `pio run -c platforms/platformio.esp32c5.ini` succeeds
- [ ] `pio run -c platforms/platformio.esp32c6.ini` succeeds
- [ ] `pio run -c platforms/platformio.esp32h2.ini` succeeds
- [ ] `pio run -c platforms/platformio.esp32p4.ini` succeeds
- [ ] Confirm the FastLED PARLIO `#warning` no longer fires on these envs

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ESP32-P4 development board

* **Chores**
  * Updated platform toolchains for ESP32-C5, ESP32-C6, and ESP32-H2 boards
  * Improved system performance optimization for LED interface across all ESP32 variants

<!-- end of auto-generated comment: release notes by coderabbit.ai -->