### PR TITLE
fix(platforms): drop toxic ARDUINO_USB_CDC_ON_BOOT / USB_MODE flags

### DIFF
--- a/platforms/platformio.esp32c3.ini
+++ b/platforms/platformio.esp32c3.ini
@@ -13,11 +13,10 @@ platform = https://github.com/pioarduino/platform-espressif32/releases/download/
 board = esp32-c3-devkitm-1
 framework = arduino
 
-; USB CDC Configuration
-; Set to 0 to disable USB CDC on boot (halts printing until serial monitor is launched)
-; Set to 1 to enable USB CDC on boot (prints immediately without waiting for serial monitor)
-build_flags =
-  -DARDUINO_USB_CDC_ON_BOOT=0
+; Do NOT add -DARDUINO_USB_CDC_ON_BOOT=1. With CDC-on-boot enabled, Serial is
+; routed to the USB-CDC interface, which only enumerates when a USB host is
+; connected — boards powered from a wall adapter then hang in setup() the
+; moment user code touches Serial. Leave Serial on the UART (default).
 
 lib_deps =
   FastLED

--- a/platforms/platformio.esp32c6.ini
+++ b/platforms/platformio.esp32c6.ini
@@ -30,14 +30,15 @@ monitor_filters =
 ; Without these the FastLED PARLIO TX ISR sits in flash and takes cache-miss
 ; stalls during execution, silently corrupting LED protocol timing.
 ; See FastLED src/platforms/esp/32/drivers/parlio/ for the canonical chipset list.
+;
+; Do NOT add -DARDUINO_USB_CDC_ON_BOOT=1 here. It wires Serial to the USB-CDC
+; interface, which only enumerates when a USB host is connected — sketches
+; that touch Serial in setup() then hang when the board is powered from a
+; wall adapter instead of a PC.
 build_flags =
     -DCONFIG_PARLIO_TX_ISR_HANDLER_IN_IRAM=1
     -DCONFIG_PARLIO_TX_ISR_CACHE_SAFE=1
-    ; ---- CRITICAL: enable USB CDC serial ----
-    -D ARDUINO_USB_CDC_ON_BOOT=1
-    -D ARDUINO_USB_MODE=1
 
-; Optional: fix early prints
 board_build.flash_mode = dio
 board_upload.flash_size = 4MB
 

--- a/platforms/platformio.esp32p4.ini
+++ b/platforms/platformio.esp32p4.ini
@@ -18,10 +18,13 @@ board_build.partitions = huge_app.csv
 ; Without these the FastLED PARLIO TX ISR sits in flash and takes cache-miss
 ; stalls during execution, silently corrupting LED protocol timing.
 ; See FastLED src/platforms/esp/32/drivers/parlio/ for the canonical chipset list.
+;
+; Do NOT add -DARDUINO_USB_CDC_ON_BOOT=1 or -DARDUINO_USB_MODE=1 here. They
+; wire Serial to the USB-CDC interface, which only enumerates when a USB host
+; is connected — boards powered from a wall adapter then hang in setup().
 build_flags =
   -DCONFIG_PARLIO_TX_ISR_HANDLER_IN_IRAM=1
   -DCONFIG_PARLIO_TX_ISR_CACHE_SAFE=1
-  -DARDUINO_USB_MODE=1
 
 lib_deps =
   FastLED


### PR DESCRIPTION
## Summary

Drop `-DARDUINO_USB_CDC_ON_BOOT=1` and `-DARDUINO_USB_MODE=1` from the ESP32 board envs that were carrying them.

- `esp32c6`: removed both flags from `build_flags`
- `esp32p4`: removed `ARDUINO_USB_MODE=1` (originally added per the #9 spec)
- `esp32c3`: removed the explicit `=0` stanza — default is already safe, and the surrounding comment had the two states reversed

Each affected ini also gets a short "Do NOT add" comment so the flag doesn't silently come back in future PRs.

## Why this matters

With `ARDUINO_USB_CDC_ON_BOOT=1`, the Arduino-ESP32 core routes `Serial` to the USB-CDC interface, which only enumerates when a USB host is connected. Boards powered from a wall adapter then hang in `setup()` the moment user code touches `Serial`.

This is exactly the failure mode a starter repo must not ship with: users copy these envs as their starting point, the fixture works on the bench (plugged into a PC), and then stops working the moment they deploy it on a wall adapter.

## Test plan

- [ ] `pio run -c platforms/platformio.esp32c3.ini` still succeeds
- [ ] `pio run -c platforms/platformio.esp32c6.ini` still succeeds
- [ ] `pio run -c platforms/platformio.esp32p4.ini` still succeeds
- [ ] Confirm a C6 sketch with `Serial.begin(115200); Serial.println("hi");` in `setup()` now boots on a wall adapter (no host connected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability for ESP32 C3, C6, and P4 boards by adjusting default serial communication settings, preventing potential hangs during initialization when devices are powered without a USB host connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->