### PR TITLE
docs(esp32p4): correct USB CDC warning — only CDC_ON_BOOT is toxic

### DIFF
--- a/platforms/platformio.esp32p4.ini
+++ b/platforms/platformio.esp32p4.ini
@@ -19,9 +19,15 @@ board_build.partitions = huge_app.csv
 ; stalls during execution, silently corrupting LED protocol timing.
 ; See FastLED src/platforms/esp/32/drivers/parlio/ for the canonical chipset list.
 ;
-; Do NOT add -DARDUINO_USB_CDC_ON_BOOT=1 or -DARDUINO_USB_MODE=1 here. They
-; wire Serial to the USB-CDC interface, which only enumerates when a USB host
-; is connected — boards powered from a wall adapter then hang in setup().
+; Do NOT add -DARDUINO_USB_CDC_ON_BOOT=1 here. It wires Serial to the USB-CDC
+; interface, which only enumerates when a USB host is connected — sketches
+; that touch Serial in setup() (especially `while (!Serial) {}`) then hang
+; when the board is powered from a wall adapter instead of a PC.
+;
+; ARDUINO_USB_MODE selects HWCDC vs TinyUSB *when CDC-on-boot is enabled*;
+; it has no effect on Serial routing while CDC_ON_BOOT=0, so we leave it
+; unset here. P4's upstream default is 0 (TinyUSB); C3/C5/C6/H2 force it to
+; 1 (HWCDC) via platform.txt.
 build_flags =
   -DCONFIG_PARLIO_TX_ISR_HANDLER_IN_IRAM=1
   -DCONFIG_PARLIO_TX_ISR_CACHE_SAFE=1


### PR DESCRIPTION
## Summary

Comment-only fix to the `platforms/platformio.esp32p4.ini` warning block added in PR #11.

The previous comment lumped `ARDUINO_USB_MODE=1` together with `ARDUINO_USB_CDC_ON_BOOT=1` as flags to avoid. After reading the Arduino-ESP32 core source (`cores/esp32/{HWCDC,USBCDC,main}.cpp`) and `platform.txt`, that conflation was wrong.

## What `ARDUINO_USB_MODE` actually does

- It only selects which USB stack backs `Serial` **when `CDC_ON_BOOT=1`**. With `CDC_ON_BOOT=0` (our default), `Serial` falls back to UART0 regardless of `USB_MODE` and the flag has no observable effect.
- `=1` → HWCDC (passive ROM-backed USB-Serial/JTAG peripheral). Bounded ~2s write timeouts; does **not** wait for host enumeration.
- `=0` → TinyUSB. This **is** the stack that blocks waiting for the host. It's the actual hang source when `CDC_ON_BOOT=1` is paired with it.
- Espressif's `platform.txt` hard-codes `=1` for C3/C5/C6/H2/C61. S3 defaults to `=1`; P4 defaults to `=0`.

## Why no build-flag change

`ARDUINO_USB_MODE` doesn't matter for our envs because we don't set `CDC_ON_BOOT=1`. Leaving it unset matches each chip's upstream default and avoids cosmetic noise. Only the comment needed correcting — the comment was misleading future readers into thinking `USB_MODE=1` was itself dangerous.

## Test plan

- [ ] `pio run -c platforms/platformio.esp32p4.ini` still succeeds (no build-flag change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)