### PR TITLE
Add NXP LPC8xx (LPC845, LPC804) PlatformIO envs

### DIFF
--- a/platforms/platformio.lpc804.ini
+++ b/platforms/platformio.lpc804.ini
@@ -1,0 +1,26 @@
+; PlatformIO Project Configuration File
+;
+; Bare NXP LPC804M101 (no dev-kit-specific pin mapping).
+; Cortex-M0+ @ 15 MHz, 4 KB SRAM / 32 KB Flash.
+;
+; IMPORTANT: at 15 MHz the bit-bang clockless driver does NOT meet WS2812
+; protocol timing. To drive WS2812-class LEDs from an LPC804 you must opt
+; into the PLU (Programmable Logic Unit) fast path
+; (clockless_arm_lpc_plu.h) by uncommenting -DFASTLED_LPC_PLU below. The
+; PLU synthesizes the bitstream in the chip's 26-LUT hardware fabric.
+;
+; The platform package is NOT in the upstream PlatformIO registry. We use
+; the zackees/platform-nxplpc-arduino fork (adds the Arduino framework
+; binding via ArduinoCore-LPC8xx). The SHA below is pinned to match
+; FastLED master's own platformio.ini.
+
+[env:lpc804]
+platform = https://github.com/zackees/platform-nxplpc-arduino.git#2ee527ae80de98e9105329a7260edb003289dfda
+board = lpc804
+framework = arduino
+
+build_flags =
+    ; -DFASTLED_LPC_PLU   ; uncomment for WS2812-class LED output
+
+lib_deps =
+    FastLED

--- a/platforms/platformio.lpc845.ini
+++ b/platforms/platformio.lpc845.ini
@@ -1,0 +1,21 @@
+; PlatformIO Project Configuration File
+;
+; Bare NXP LPC845M301 (no dev-kit-specific pin mapping).
+; Cortex-M0+ @ 24 MHz, 16 KB SRAM / 64 KB Flash.
+;
+; FastLED uses the bit-bang clockless driver (clockless_arm_lpc.h /
+; m0clockless_c.h) by default. For the SCT+DMA fast path see the
+; lpc845brk env (-DFASTLED_LPC_PWM_DMA=1).
+;
+; The platform package is NOT in the upstream PlatformIO registry. We use
+; the zackees/platform-nxplpc-arduino fork (adds the Arduino framework
+; binding via ArduinoCore-LPC8xx). The SHA below is pinned to match
+; FastLED master's own platformio.ini.
+
+[env:lpc845]
+platform = https://github.com/zackees/platform-nxplpc-arduino.git#2ee527ae80de98e9105329a7260edb003289dfda
+board = lpc845
+framework = arduino
+
+lib_deps =
+    FastLED

--- a/platforms/platformio.lpc845brk.ini
+++ b/platforms/platformio.lpc845brk.ini
@@ -1,0 +1,24 @@
+; PlatformIO Project Configuration File
+;
+; NXP LPC845-BRK breakout — recommended starting point for LPC845.
+; Cortex-M0+ @ 24 MHz, 16 KB SRAM / 64 KB Flash.
+;
+; This env opts into the FastLED LPC845 fast path
+; (clockless_arm_lpc_pwm_dma.h — SCT + 3-channel DMA-to-GPIO). Drop the
+; FASTLED_LPC_PWM_DMA flag if you'd rather use the plain bit-bang driver.
+;
+; The platform package is NOT in the upstream PlatformIO registry. We use
+; the zackees/platform-nxplpc-arduino fork (adds the Arduino framework
+; binding via ArduinoCore-LPC8xx). The SHA below is pinned to match
+; FastLED master's own platformio.ini.
+
+[env:lpc845brk]
+platform = https://github.com/zackees/platform-nxplpc-arduino.git#2ee527ae80de98e9105329a7260edb003289dfda
+board = lpc845brk
+framework = arduino
+
+build_flags =
+    -DFASTLED_LPC_PWM_DMA=1
+
+lib_deps =
+    FastLED

--- a/platforms/platformio.lpcxpresso804.ini
+++ b/platforms/platformio.lpcxpresso804.ini
@@ -1,0 +1,25 @@
+; PlatformIO Project Configuration File
+;
+; NXP LPCXpresso804 development board (LPC804-based).
+; Cortex-M0+ @ 15 MHz, 4 KB SRAM / 32 KB Flash.
+;
+; IMPORTANT: same 15 MHz constraint as [env:lpc804]. To drive WS2812-class
+; LEDs you must opt into the PLU fast path (clockless_arm_lpc_plu.h) by
+; uncommenting -DFASTLED_LPC_PLU below — the plain bit-bang driver cannot
+; meet WS2812 timing at this clock speed.
+;
+; The platform package is NOT in the upstream PlatformIO registry. We use
+; the zackees/platform-nxplpc-arduino fork (adds the Arduino framework
+; binding via ArduinoCore-LPC8xx). The SHA below is pinned to match
+; FastLED master's own platformio.ini.
+
+[env:lpcxpresso804]
+platform = https://github.com/zackees/platform-nxplpc-arduino.git#2ee527ae80de98e9105329a7260edb003289dfda
+board = lpcxpresso804
+framework = arduino
+
+build_flags =
+    ; -DFASTLED_LPC_PLU   ; uncomment for WS2812-class LED output
+
+lib_deps =
+    FastLED

--- a/platforms/platformio.lpcxpresso845max.ini
+++ b/platforms/platformio.lpcxpresso845max.ini
@@ -1,0 +1,20 @@
+; PlatformIO Project Configuration File
+;
+; NXP LPCXpresso845MAX development board (LPC845-based).
+; Cortex-M0+ @ 24 MHz, 16 KB SRAM / 64 KB Flash.
+;
+; FastLED uses the bit-bang clockless driver by default on this env.
+; To opt into the SCT+DMA fast path add: -DFASTLED_LPC_PWM_DMA=1
+;
+; The platform package is NOT in the upstream PlatformIO registry. We use
+; the zackees/platform-nxplpc-arduino fork (adds the Arduino framework
+; binding via ArduinoCore-LPC8xx). The SHA below is pinned to match
+; FastLED master's own platformio.ini.
+
+[env:lpcxpresso845max]
+platform = https://github.com/zackees/platform-nxplpc-arduino.git#2ee527ae80de98e9105329a7260edb003289dfda
+board = lpcxpresso845max
+framework = arduino
+
+lib_deps =
+    FastLED


### PR DESCRIPTION
## Summary

Add five PlatformIO envs covering the parts FastLED's `src/platforms/arm/lpc/` tree supports today:

- `lpc845brk` — LPC845-BRK breakout, opts into the SCT + 3-channel DMA-to-GPIO fast path via `-DFASTLED_LPC_PWM_DMA=1`.
- `lpc845` — bare LPC845M301 (bit-bang clockless by default).
- `lpcxpresso845max` — LPCXpresso845MAX dev board.
- `lpc804` — bare LPC804M101 with a commented-out `-DFASTLED_LPC_PLU` hint (mandatory for WS2812 timing at the part's 15 MHz core clock).
- `lpcxpresso804` — LPCXpresso804 dev board, same caveat as `lpc804`.

## Why

FastLED has shipped first-class support for the LPC845 and LPC804 (Cortex-M0+), but `PlatformIO-Starter` had no envs targeting them. The platform package isn't in the PlatformIO registry either — users need the `zackees/platform-nxplpc-arduino` fork plus per-board IDs — so without these envs the on-ramp is "go reverse-engineer FastLED's `platformio.ini`."

Each ini has a header comment noting the part's RAM/Flash budget, the chip-specific fast-path build flag, and the non-registry platform source so future maintainers don't get tripped up.

## Boards intentionally NOT added

- **LPC11U24/U35**, **LPC11 legacy**, **LPC15xx** — supported by FastLED but out of scope for the LPC8xx issue. File a follow-up if/when wanted.
- **LPC810/811/812/822/824/844/83x/834x** — NOT supported by FastLED; would be a footgun.

## Test plan

- [ ] `pio run -c platforms/platformio.lpc845brk.ini` succeeds
- [ ] `pio run -c platforms/platformio.lpc845.ini` succeeds
- [ ] `pio run -c platforms/platformio.lpcxpresso845max.ini` succeeds
- [ ] `pio run -c platforms/platformio.lpc804.ini` succeeds
- [ ] `pio run -c platforms/platformio.lpcxpresso804.ini` succeeds
- [ ] On an LPC845-BRK with WS2812 wired, verify the `FASTLED_LPC_PWM_DMA` fast path is selected (FastLED's `#ifdef` for `clockless_arm_lpc_pwm_dma.h`)

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added firmware build configurations for five NXP LPC microcontroller development boards
  * Enables compilation and deployment across multiple LPC804 and LPC845 hardware platforms
  * Each configuration includes board-specific settings and optimizations
  * Integrated FastLED library support for LED control capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->